### PR TITLE
fixed capitalisation issue on mdref example

### DIFF
--- a/application/deed/deed-api.json
+++ b/application/deed/deed-api.json
@@ -153,7 +153,7 @@
                         },
                         "md_ref": {
                             "type": "string",
-                            "description": "Land Registry assigned number for a Mortgage Deed (MD). If you wish to use an existing MD reference please prefix it with e- to comply with our system (eg e-md12345)"
+                            "description": "Land Registry assigned number for a Mortgage Deed (MD). If you wish to use an existing MD reference please prefix it with e- to comply with our system (eg e-MD12345)"
                         },
                         "borrowers": {
                             "$ref": "#/definitions/Borrowers"


### PR DESCRIPTION
Corrects a capitalisation error in the midriff example given in the son schema
