### PR TITLE
refactored create deed endpoint to return reletive url for GET

### DIFF
--- a/application/deed/views.py
+++ b/application/deed/views.py
@@ -126,7 +126,7 @@ def create():
 
             deed.save()
 
-            url = request.base_url + str(deed.token)
+            url = "/deed/" + str(deed.token)
 
             return jsonify({"url": url}), status.HTTP_201_CREATED
 

--- a/application/deed/views.py
+++ b/application/deed/views.py
@@ -126,9 +126,9 @@ def create():
 
             deed.save()
 
-            url = "/deed/" + str(deed.token)
+            path = "/deed/" + str(deed.token)
 
-            return jsonify({"url": url}), status.HTTP_201_CREATED
+            return jsonify({"path": path}), status.HTTP_201_CREATED
 
         except Exception as e:
             LOGGER.error("Database Exception - %s" % e)

--- a/integration_tests/deed/test_deed.py
+++ b/integration_tests/deed/test_deed.py
@@ -26,7 +26,7 @@ class TestDeedRoutes(unittest.TestCase):
         self.assertIn("/deed/", str(create_deed.data))
 
         response_json = json.loads(create_deed.data.decode())
-        get_created_deed = client.get(response_json["url"])
+        get_created_deed = client.get(response_json["path"])
         self.assertEqual(get_created_deed.status_code, 200)
 
         self.assertIn("title_number", str(get_created_deed.data))
@@ -62,7 +62,7 @@ class TestDeedRoutes(unittest.TestCase):
         self.assertIn("token", str(get_created_deed.data))
         self.assertIn("status", str(get_created_deed.data))
         self.assertIn("DRAFT", str(get_created_deed.data))
-        self.assertIn(response_json["url"][-6:], str(get_created_deed.data))
+        self.assertIn(response_json["path"][-6:], str(get_created_deed.data))
 
     @with_client
     def test_invalid_params_on_get_with_mdref_and_titleno(self, client):


### PR DESCRIPTION
After discussion and agreement on restful best practice have refactored create deed endpoint to return the relative url for the get endpoint instead of the full url.
