### PR TITLE
Removal of salting of uuids

### DIFF
--- a/application/borrower/model.py
+++ b/application/borrower/model.py
@@ -17,7 +17,7 @@ class Borrower(db.Model):
 
     @staticmethod
     def generate_token():
-        return str(uuid.uuid4().hex).lower()
+        return str(uuid.uuid4().hex[:6]).lower()
 
     def save(self):
         db.session.add(self)

--- a/application/borrower/model.py
+++ b/application/borrower/model.py
@@ -1,6 +1,7 @@
 from application import db
 import uuid
 
+
 class Borrower(db.Model):
     __tablename__ = 'borrower'
 

--- a/application/borrower/model.py
+++ b/application/borrower/model.py
@@ -1,7 +1,5 @@
 from application import db
 import uuid
-from hashids import Hashids
-
 
 class Borrower(db.Model):
     __tablename__ = 'borrower'
@@ -19,10 +17,7 @@ class Borrower(db.Model):
 
     @staticmethod
     def generate_token():
-        uuid_value = str(uuid.uuid4().hex).lower()
-        hashids = Hashids(salt=uuid_value, alphabet='abcdef0123456789')
-        hashid = hashids.encode(123, 4)
-        return hashid
+        return str(uuid.uuid4().hex).lower()
 
     def save(self):
         db.session.add(self)

--- a/application/deed/model.py
+++ b/application/deed/model.py
@@ -28,7 +28,7 @@ class Deed(db.Model):
 
     @staticmethod
     def generate_token():
-        return str(uuid.uuid4().hex).lower()
+        return str(uuid.uuid4().hex[:6]).lower()
 
     def get_json_doc(self):
         return copy.deepcopy(self.json_doc)

--- a/application/deed/model.py
+++ b/application/deed/model.py
@@ -4,7 +4,6 @@ from application import db
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.sql.operators import and_
 from application.deed.utils import process_organisation_credentials
-from hashids import Hashids
 import logging
 
 LOGGER = logging.getLogger(__name__)
@@ -29,10 +28,7 @@ class Deed(db.Model):
 
     @staticmethod
     def generate_token():
-        uuid_value = str(uuid.uuid4().hex).lower()
-        hashids = Hashids(salt=uuid_value, alphabet='abcdef0123456789')
-        hashid = hashids.encode(123, 4)
-        return hashid
+        return str(uuid.uuid4().hex).lower()
 
     def get_json_doc(self):
         return copy.deepcopy(self.json_doc)


### PR DESCRIPTION
Removal of Hashids function and the corresponding import. This should allow our acceptance tests to not create duplicate borrower tokens.
