### PR TITLE
Tolerate all return values on akuma.

### DIFF
--- a/application/deed/service.py
+++ b/application/deed/service.py
@@ -91,8 +91,7 @@ def update_deed(deed, deed_json, akuma_flag):
     update_borrower_for_token = partial(update_borrower, deed_token=deed.token)
 
     borrower_json = _(borrowers).chain()\
-        .map(update_borrower_for_token)\
-        .value() if akuma_flag == "A" else None
+        .map(update_borrower_for_token).value()
 
     json_doc['borrowers'] = borrower_json
 

--- a/application/deed/views.py
+++ b/application/deed/views.py
@@ -84,10 +84,6 @@ def create():
                 LOGGER.error("Unable to process headers")
                 return "Unable to process headers", status.HTTP_401_UNAUTHORIZED
 
-            if check_result['result'] != "A":
-                LOGGER.error("Akuma endpoint 503_SERVICE_UNAVAILABLE")
-                return abort(status.HTTP_503_SERVICE_UNAVAILABLE)
-
             return jsonify({"path": '/deed/' + str(deed.token)}), status.HTTP_201_CREATED
 
         except:

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -296,27 +296,6 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(check_result["result"], "A")
 
-    @mock.patch('application.service_clients.akuma.interface.AkumaInterface.perform_check')
-    @mock.patch('application.deed.service', autospec=True)
-    @mock.patch('application.borrower.model.Borrower.save')
-    @mock.patch('application.deed.model.Deed.save')
-    @mock.patch('application.mortgage_document.model.MortgageDocument.query', autospec=True)
-    def test_create_invalid_akuma(self, mock_query, mock_Deed, mock_Borrower, mock_update, mock_akuma):
-        mock_instance_response = mock_query.filter_by.return_value
-        mock_instance_response.first.return_value = MortgageDocMock()
-        mock_update.update_deed.return_value = True, "OK"
-        mock_akuma.return_value = {
-            "result": "FFFFF",
-            "id": "2b9115b2-d956-11e5-942f-08002719cd16"
-        }
-
-        payload = json.dumps(DeedHelper._json_doc)
-
-        response = self.app.post(self.DEED_ENDPOINT, data=payload,
-                                 headers=self.webseal_headers)
-
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
     def test_make_effective_clause(self):
 
         effective_clause = make_effective_text("Test Organisation")


### PR DESCRIPTION
This removes the checks around the akuma.do_check return value.

Compromised by tech debt:
- No unittest hit the update_deed directly. The code is exercised by test_create_webseal_external and test_invalid_mdref hence giving the appearance of coverage.
- update_deed contains too much cyclomatic to sensibly test without refactoring. Specifically in the line which has been changed.
